### PR TITLE
Support both react-native-vector-icons & react-native-icons

### DIFF
--- a/ItemCheckbox.js
+++ b/ItemCheckbox.js
@@ -1,46 +1,54 @@
 'use strict';
 
 var React = require('react-native');
-var { Icon, } = require('react-native-icons');
+
 
 var {
-  AppRegistry,
-  StyleSheet,
-  Text,
+  PropTypes,
   View,
-  TouchableWithoutFeedback,
+  Text,
+  TouchableHighlight,
+  TouchableWithoutFeedback
 } = React;
 
 var ItemCheckbox = React.createClass({
   propTypes: {
+    icon: PropTypes.func,
+    icon_check: PropTypes.string,
+    icon_open: PropTypes.string,
     onCheck: React.PropTypes.func,
     onUncheck: React.PropTypes.func,
-    icon: React.PropTypes.String,
     size: React.PropTypes.number,
     backgroundColor: React.PropTypes.String,
     color: React.PropTypes.String,
     iconSize: React.PropTypes.String,
     checked: React.PropTypes.bool,
     style: React.PropTypes.func,
+    text: PropTypes.string,
+    disabled: PropTypes.bool
   },
 
   getDefaultProps: function() {
     return {
+      icon: null,
       onCheck: null,
       onUncheck: null,
-      icon: "check",
+      icon_check: "check-square",
+      icon_open: "square-o",
       size: 30,
       backgroundColor: 'white',
       color: 'grey',
       iconSize: 'normal,',
       checked: false,
+      text: 'MISSING TEXT',
+      disabled: false
     };
   },
 
   getInitialState: function () {
     return {
-      checked: false,
-      bg_color: this.props.backgroundColor,
+      checked: this.props.checked,
+      bg_color: this.props.backgroundColor
     };
   },
 
@@ -104,25 +112,54 @@ var ItemCheckbox = React.createClass({
   },
 
   render: function() {
-    var icon = 'fontawesome|' + this.props.icon;
-    return(
-      <View style={this.props.style}>
-        <TouchableWithoutFeedback
-          onPress={this._completeProgress}
-          >
-          <View style={this._getCircleCheckStyle()}>
-            <Icon
-              name={'fontawesome|' + this.props.icon}
-              size={this._getIconSize()}
-              color={this.props.backgroundColor}
-              backgroundColor='transparent'
-              style={this._getCircleIconStyle()}
-            />
+    var iconName=this.props.icon_open;
+    if (this.state.checked) {
+      iconName=this.props.icon_check;
+    }
+
+    let Icon = this.props.icon;
+    
+    if (this.props.disabled) {
+      iconName = this.props.checked ? this.props.icon_check : this.props.icon_open;
+      return (
+        <View style={this.props.style}>
+          <TouchableWithoutFeedback>
+            <View style={{
+                flexDirection: 'row',
+                flex:1
+              }}>
+              <Icon
+                  name={iconName}
+                  size={20}
+                  style={this._getCircleIconStyle}
+              />
+              <Text> {this.props.text}</Text>
+            </View>
+          </TouchableWithoutFeedback>
+        </View>
+        );
+      } else {
+        return(
+          <View style={this.props.style}>
+            <TouchableHighlight
+                onPress={this._completeProgress}
+            >
+              <View style={{
+                  flexDirection: 'row',
+                  flex:1
+                }}>
+                <Icon
+                    name={iconName}
+                    size={20}
+                    style={this._getCircleIconStyle}
+                />
+                <Text> {this.props.text}</Text>
+              </View>
+            </TouchableHighlight>
           </View>
-        </TouchableWithoutFeedback>
-      </View>
-    );
-  },
+        ); //return
+      }//else
+    } //render
 });
 
 module.exports = ItemCheckbox;


### PR DESCRIPTION
_Nice_ component - I have my modified version here: [https://github.com/bartonhammond/snowflake](https://github.com/bartonhammond/snowflake) which is what I'm wanting to merge with yours.

I use it thusly:
- _Login_ - toggles the display of Password fields
- _Profile_ - displays the email-verified field which is read only

This merge would do the following:
- Extract out the hard dependancy of Icon - pass it in as a property of type `PropTypes.func`
- Support the user pass property of react-native-vector-icons or react-native-icons
- Add support for passing the text property for display next to icon
- I need the text all the time but it should be conditional 
- Add support for a "read-only" non feedback version (for display only )

I think there might be some style properties that apply to one Icon and not the other. A switch statement could be necessary to style both maybe.  With this merge it looks exactly like you see in my demo.  If I have the transparency and background the icon disappears.  Maybe you can figure out what properties are in common....It's close now though.

In my app I am calling it thusly:

```
    /**
    * Toggle the display of the Password and PasswordAgain fields
    */
    import Icon from 'react-native-vector-icons/FontAwesome';
    let itemCheckBox =
    <ItemCheckbox
        icon={Icon}
        text="Show Password"
        disabled={this.props.auth.form.isFetching}
        onCheck={() => {
            this.props.actions.onAuthFormFieldChange('showPassword',true)}
        }
        onUncheck={() => {
            this.props.actions.onAuthFormFieldChange('showPassword',false)}
        }
    />;
```

hope this helps.... -barton
