### PR TITLE
Make ItemCheckbox a controlled component

### DIFF
--- a/ItemCheckbox.js
+++ b/ItemCheckbox.js
@@ -78,7 +78,7 @@ export default class ItemCheckbox extends React.Component {
     };
   }
 
-  _setStatus(checked, doInvoke) {
+  _setStatus(checked) {
     // Assume unchecked
     var bg_color = this.props.backgroundColor;
     var invokable = this.props.onUncheck;
@@ -93,14 +93,10 @@ export default class ItemCheckbox extends React.Component {
       checked,
       bg_color
     });
-
-    if(doInvoke) {
-      invokable();
-    }
   }
 
   _checkItem(checked) {
-    this._setStatus(checked, false);
+    this._setStatus(checked);
   }
 
   componentDidMount() {

--- a/ItemCheckbox.js
+++ b/ItemCheckbox.js
@@ -24,7 +24,6 @@ export default class ItemCheckbox extends React.Component {
     color: React.PropTypes.string,
     iconSize: React.PropTypes.string,
     checked: React.PropTypes.bool,
-    default: React.PropTypes.bool,
   };
 
   static defaultProps = {
@@ -36,7 +35,6 @@ export default class ItemCheckbox extends React.Component {
     color: 'grey',
     iconSize: 'normal',
     checked: false,
-    default: false,
   };
 
   constructor(props, context) {
@@ -80,37 +78,44 @@ export default class ItemCheckbox extends React.Component {
     };
   }
 
-  _completeProgress(defaultValue) {
-    if (this.state.checked) {
-      this.setState({
-        checked: false,
-        bg_color: this.props.backgroundColor,
-      });
-      if (this.props.onUncheck && !defaultValue) {
-        this.props.onUncheck();
-      }
-    } else {
-      this.setState({
-        checked: true,
-        bg_color: this.props.color,
-      });
-      if (this.props.onCheck && !defaultValue) {
-        this.props.onCheck();
-      }
+  _setStatus(checked, doInvoke) {
+    // Assume unchecked
+    var bg_color = this.props.backgroundColor;
+    var invokable = this.props.onUncheck;
+
+    // If checked
+    if (checked) {
+      bg_color = this.props.color;
+      invokable = this.props.onCheck;
+    }
+
+    this.setState({
+      checked,
+      bg_color
+    });
+
+    if(doInvoke) {
+      invokable();
     }
   }
 
-  _initDefault() {
-    this._completeProgress(true);
+  _checkItem(checked) {
+    this._setStatus(checked, false);
   }
 
   componentDidMount() {
-    if (this.props.checked) {
-      this._completeProgress(false);
-    }
+    this._checkItem(this.props.checked);
+  }
 
-    if (this.props.default) {
-      this._initDefault();
+  componentWillReceiveProps(nextProps) {
+    this._checkItem(nextProps.checked);
+  }
+
+  _onPress() {
+    if(this.state.checked) {
+      this.props.onUncheck();
+    } else {
+      this.props.onCheck();
     }
   }
 
@@ -119,7 +124,7 @@ export default class ItemCheckbox extends React.Component {
     return (
       <View style={this.props.style}>
         <TouchableWithoutFeedback
-          onPress={this._completeProgress.bind(this, false)}
+          onPress={this._onPress.bind(this)}
           >
           <View style={this._getCircleCheckStyle()}>
             <Icon

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Don't forget to run ```rnpm link```
 #### **Basic usage**
 
 <ItemCheckbox onCheck={this._yourCallback} />
-This basic line will generate a standard checkbox with a 'check' symbol for you. 
+This basic line will generate a standard checkbox with a 'check' symbol for you.
 
 #### **Options**
 Option  | default value | values
@@ -24,20 +24,19 @@ size (PropTypes.number) | 18  | the size of your checkbox button
 backgroundColor (PropTypes.String) | 'grey'  | colors
 color (PropTypes.String) | 'white'  | colors
 iconSize (PropTypes.String) | 'normal'  | {'small', 'normal', 'large'}
-checked (PropTypes.bool) | false  | {true, false} (calles onCheck or onUncheck)
-default (PropTypes.bool) | false  | {true, false} (doesn't call onCheck or onUncheck)
+checked (PropTypes.bool) | false  | {true, false} You have to change this value to change the displayed status
 style (PropTypes.func) | null  | custom style
 
 #### **Examples**
-```
+```javascript
 var ItemCheckbox = require('react-native-item-checkbox');
 
 // inside your render function
-<ItemCheckbox /> // 
+<ItemCheckbox /> //
 ```
 ![Gif](http://i.imgur.com/34gKmoX.gif)
 
-```
+```javascript
 // ...
 _onCheckCallback: function() {
   alert('checked');
@@ -47,7 +46,7 @@ _onCheckCallback: function() {
   onCheck={this._onCheckCallback}
 />
 ```
-```
+```javascript
 <ItemCheckbox //example with icon settings
   color="#FF9999"
   icon="tree"

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ size (PropTypes.number) | 18  | the size of your checkbox button
 backgroundColor (PropTypes.String) | 'grey'  | colors
 color (PropTypes.String) | 'white'  | colors
 iconSize (PropTypes.String) | 'normal'  | {'small', 'normal', 'large'}
-checked (PropTypes.bool) | false  | {true, false} You have to change this value to change the displayed status
+checked (PropTypes.bool) | false  | {true, false} You have to change this value to change the displayed status(controlled value)
 style (PropTypes.func) | null  | custom style
 
 #### **Examples**
@@ -62,4 +62,6 @@ _onCheckCallback: function() {
 
 ![Gif](http://i.imgur.com/r9w1cmg.png)
 
-```iconSize={"small", "normal", "large"}```
+```javascript
+iconSize={"small", "normal", "large"}
+```


### PR DESCRIPTION
Hey, nice work.
I used ItemCheckbox and encountered an issue when I wanted the check value to be determined by the application state - when the relevant state changed the ItemCheckbox would re-render but without changing the display or taking into account the new "checked" property value.

Changes:
- Made ItemCheckbox a controlled component so its value will be managed by the containing component(which solved my issue).
- Removed the default property since it had no good use anymore.
- Minor updates to the readme 
